### PR TITLE
PLUG-106 Feat : 로그아웃 api 추가

### DIFF
--- a/src/main/java/com/justdo/plug/member/domain/auth/AuthController.java
+++ b/src/main/java/com/justdo/plug/member/domain/auth/AuthController.java
@@ -1,5 +1,0 @@
-package com.justdo.plug.member.domain.auth;
-
-public class AuthController {
-
-}

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -38,12 +38,10 @@ public class MemberController {
     }
 
     @PostMapping("/logout")
-    public ApiResponse<Object> logout(HttpServletRequest request){
+    public void logout(HttpServletRequest request){
         String accessToken = request.getHeader("Authorization");
 
         memberService.logout(accessToken);
-
-        return ApiResponse.onSuccess(null);
     }
 
 

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members/**")
+@RequestMapping("/members")
 @Slf4j
 
 public class MemberController {
@@ -23,7 +23,7 @@ public class MemberController {
 
         String accessToken = request.getHeader("Authorization");
 
-        MemberInfoResponse memberInfo = memberService.getInfo(accessToken);
+        MemberInfoResponse memberInfo = memberService.getMemberInfo(accessToken);
 
         return ApiResponse.onSuccess(memberInfo);
     }
@@ -32,9 +32,20 @@ public class MemberController {
     public ApiResponse<MemberInfoResponse> updateMyInfo(HttpServletRequest request, @RequestBody MemberInfoRequest memberInfoRequest){
         String accessToken = request.getHeader("Authorization");
 
-        MemberInfoResponse memberInfo = memberService.updateInfo(accessToken,memberInfoRequest);
+        MemberInfoResponse memberInfo = memberService.updateMemberInfo(accessToken,memberInfoRequest);
 
         return ApiResponse.onSuccess(memberInfo);
     }
+
+    @PostMapping("/logout")
+    public ApiResponse<Object> logout(HttpServletRequest request){
+        String accessToken = request.getHeader("Authorization");
+
+        memberService.logout(accessToken);
+
+        return ApiResponse.onSuccess(null);
+    }
+
+
 
 }


### PR DESCRIPTION
## 📌 요약

- 멤버 로그아웃 api를 추가하였습니다.

## 📝 상세 내용

- 헤더에서 access 토큰 값을 뽑아내고 해당하는 userId key 값으로 redis에 존재하는 refresh 토큰을 삭제하였습니다.

<img width="872" alt="image" src="https://github.com/DoTheZ-Team/auth-service/assets/113875098/19747518-7389-4444-93fa-9c4e1831e67e">

## 🗣️ 질문 및 이외 사항

- 현재 member controller에서 헤더에서 토큰 값을 뽑아내는 로직이 중복되고 있는데, 현재 서비스에서 필터로 처리할까 하였지만 아무래도 게이트웨이 서버에서 인가처리를 진행할 때 이를 같이 해결해야 할 것 같습니다. 
- 로그아웃 api의 반환 형식을 void로 일단 처리하였는데 ApiResponse 객체 응답값에 맞게 주는 것이 맞을지 어떤게 좋은지 궁금합니다.

## ☑️ 이슈 번호

- close #
