### PR TITLE
PLUG-149 Feat : access 토큰 재발급 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.justdo.plug.member.domain.member.dto.response.MemberInfoResponse;
 import com.justdo.plug.member.domain.member.service.MemberService;
 import com.justdo.plug.member.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -44,6 +45,15 @@ public class MemberController {
         memberService.logout(accessToken);
     }
 
+    @PostMapping("/reissue")
+    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response){
+        String accessToken = request.getHeader("Authorization");
+        String refreshToken = request.getHeader("Authorization-refresh");
+
+        String newAccessToken = memberService.reissueAccessToken(accessToken, refreshToken);
+
+        response.setHeader("Authorization", newAccessToken);
+    }
 
 
 }

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -8,7 +8,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,23 +35,26 @@ public class MemberController {
     }
 
     @PutMapping
-    public ApiResponse<MemberInfoResponse> updateMyInfo(HttpServletRequest request, @RequestBody MemberInfoRequest memberInfoRequest){
+    public ApiResponse<MemberInfoResponse> updateMyInfo(HttpServletRequest request,
+        @RequestBody MemberInfoRequest memberInfoRequest) {
         String accessToken = request.getHeader("Authorization");
 
-        MemberInfoResponse memberInfo = memberService.updateMemberInfo(accessToken,memberInfoRequest);
+        MemberInfoResponse memberInfo = memberService.updateMemberInfo(accessToken,
+            memberInfoRequest);
 
         return ApiResponse.onSuccess(memberInfo);
     }
 
     @PostMapping("/logout")
-    public void logout(HttpServletRequest request){
+    public void logout(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
 
         memberService.logout(accessToken);
     }
 
+
     @PostMapping("/reissue")
-    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response){
+    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = request.getHeader("Authorization");
         String refreshToken = request.getHeader("Authorization-refresh");
 

--- a/src/main/java/com/justdo/plug/member/domain/member/service/MemberService.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/service/MemberService.java
@@ -18,12 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberService {
+
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisUtils redisUtils;
 
+
     // 멤버 정보 조회
-    public MemberInfoResponse getMemberInfo(String accessToken){
+    public MemberInfoResponse getMemberInfo(String accessToken) {
         checkToken(accessToken);
 
         Long userId = extractUserIdFromToken(accessToken);
@@ -35,7 +37,8 @@ public class MemberService {
 
     // 멤버 정보 수정
     @Transactional
-    public MemberInfoResponse updateMemberInfo(String accessToken, MemberInfoRequest memberInfoRequest){
+    public MemberInfoResponse updateMemberInfo(String accessToken,
+        MemberInfoRequest memberInfoRequest) {
         checkToken(accessToken);
 
         Long userId = extractUserIdFromToken(accessToken);
@@ -49,7 +52,7 @@ public class MemberService {
 
     // 로그아웃
     @Transactional
-    public void logout(String accessToken){
+    public void logout(String accessToken) {
         deleteRefreshToken(accessToken);
     }
 
@@ -57,9 +60,12 @@ public class MemberService {
     @Transactional
     public String reissueAccessToken(String accessToken, String refreshToken) {
         checkToken(accessToken);
+
         validateRefreshToken(refreshToken);
         Long userId = extractUserIdFromToken(accessToken);
+
         validateStoredRefreshToken(userId.toString(), refreshToken);
+
         return jwtTokenProvider.generateAccessToken(userId);
     }
 
@@ -77,7 +83,7 @@ public class MemberService {
     }
 
 
-    private void deleteRefreshToken(String accessToken){
+    private void deleteRefreshToken(String accessToken) {
         checkToken(accessToken);
 
         Long userId = extractUserIdFromToken(accessToken);
@@ -90,12 +96,12 @@ public class MemberService {
 
     }
 
-    private Member findMember(Long userId){
+    private Member findMember(Long userId) {
         return memberRepository.findById(userId).orElseThrow(
-                () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND_ERROR));
+            () -> new ApiException(ErrorStatus._MEMBER_NOT_FOUND_ERROR));
     }
 
-    private void checkToken(String accessToken){
+    private void checkToken(String accessToken) {
         if (accessToken == null || !accessToken.startsWith("Bearer ")) {
             throw new ApiException(ErrorStatus._UNAUTHORIZED);
         }
@@ -106,7 +112,7 @@ public class MemberService {
 
         Long userId = jwtTokenProvider.getUserIdFromToken(jwt);
 
-        if (userId == null){
+        if (userId == null) {
             throw new ApiException(ErrorStatus._UNAUTHORIZED);
         }
 

--- a/src/main/java/com/justdo/plug/member/domain/member/service/MemberService.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/service/MemberService.java
@@ -53,6 +53,30 @@ public class MemberService {
         deleteRefreshToken(accessToken);
     }
 
+    // 액세스 토큰 재발급
+    @Transactional
+    public String reissueAccessToken(String accessToken, String refreshToken) {
+        checkToken(accessToken);
+        validateRefreshToken(refreshToken);
+        Long userId = extractUserIdFromToken(accessToken);
+        validateStoredRefreshToken(userId.toString(), refreshToken);
+        return jwtTokenProvider.generateAccessToken(userId);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!jwtTokenProvider.isTokenValid(refreshToken)) {
+            throw new ApiException(ErrorStatus._INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private void validateStoredRefreshToken(String userId, String refreshToken) {
+        String storedRefreshToken = redisUtils.getData(userId);
+        if (!refreshToken.equals(storedRefreshToken)) {
+            throw new ApiException(ErrorStatus._INVALID_REFRESH_TOKEN);
+        }
+    }
+
+
     private void deleteRefreshToken(String accessToken){
         checkToken(accessToken);
 

--- a/src/main/java/com/justdo/plug/member/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/justdo/plug/member/global/jwt/JwtTokenProvider.java
@@ -54,7 +54,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // New method to extract userId claim
+    // userId 추출
     public Long getUserIdFromToken(String token) {
         try {
             SecretKey secretKey = getSecretKey();
@@ -66,19 +66,17 @@ public class JwtTokenProvider {
         }
     }
 
+    // 토큰 유효성 검사
+    public boolean isTokenValid(String token) {
+        try {
+            SecretKey secretKey = getSecretKey();
 
-    // 코드 수정 요망
-//    public boolean isTokenValid(String token) {
-//        try {
-//            String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());
-//            SecretKey secretKey = Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
-//
-//            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
-//            return true;
-//        } catch (JwtException e) {
-//            // 유효하지 않은 토큰이므로 false 반환
-//            return false;
-//        }
-//    }
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (JwtException e) {
+            // 유효하지 않은 토큰이므로 false 반환
+            return false;
+        }
+    }
 
 }

--- a/src/main/java/com/justdo/plug/member/global/response/code/status/ErrorStatus.java
+++ b/src/main/java/com/justdo/plug/member/global/response/code/status/ErrorStatus.java
@@ -24,9 +24,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 레디스 응답
     _REDIS_OPERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"REDIS_001","레디스 데이터 접근 중에 오류가 발생했습니다."),
     // 멤버 관련 응답
-    _MEMBER_NOT_FOUND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_001", "해당 사용자를 찾을 수 없습니다.");
-    // 추가 예정
-    // ^_^
+    _MEMBER_NOT_FOUND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MEMBER_001", "해당 사용자를 찾을 수 없습니다."),
+
+    // jwt
+    _INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_001", "유효하지 않은 리프레시 토큰입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 📌 요약

- 멤버 컨트롤러에 access 토큰을 재발급 하는 api를 추가하였습니다.

## 📝 상세 내용

- access 토큰 재발급 로직은 아래와 같습니다.
- 1. refresh 토큰 유효성 검사
- 2. redis에 저장된 토큰과 같은지 검사
- 3. 새로운 access 토큰 생성 및 반환

## 🗣️ 질문 및 이외 사항

- 로그아웃과 동일하게 응답에 대한 의문이 생깁니다. 그냥 void로 때려도 될지 모르겠습니다.

## ☑️ 이슈 번호

- close #
