### PR TITLE
Glue 249 : Feat memberId 목록을 전달하여, 이에 따른 사용자 닉네임 목록 반환 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// config & eureka
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
@@ -47,14 +51,14 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	// h2
-	runtimeOnly 'com.h2database:h2'
-
 	// openfeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// swagger
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
 }
 
 

--- a/src/main/java/com/justdo/plug/member/MemberApplication.java
+++ b/src/main/java/com/justdo/plug/member/MemberApplication.java
@@ -2,12 +2,14 @@ package com.justdo.plug.member;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableFeignClients(basePackages = {"com.justdo.plug"})
+@EnableDiscoveryClient
 public class MemberApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/justdo/plug/member/domain/member/Member.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/Member.java
@@ -23,7 +23,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "provider_id")
     private Long providerId;
 
-    @Column(length = 20)
+    @Column(length = 100)
     private String email;
 
     @Column(length = 10)

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -62,5 +62,9 @@ public class MemberController {
         response.setHeader("Authorization", newAccessToken);
     }
 
+    @PostMapping("/blogs")
+    public List<String> getMemberNicknames(@RequestBody List<Long> memberIdList) {
 
+        return memberService.getMemberNicknames(memberIdList);
+    }
 }

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.justdo.plug.member.domain.member.service.MemberService;
 import com.justdo.plug.member.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,13 +26,11 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public ApiResponse<MemberInfoResponse> getMyInfo(HttpServletRequest request) {
+    public MemberInfoResponse getMyInfo(HttpServletRequest request) {
 
         String accessToken = request.getHeader("Authorization");
 
-        MemberInfoResponse memberInfo = memberService.getMemberInfo(accessToken);
-
-        return ApiResponse.onSuccess(memberInfo);
+        return memberService.getMemberInfo(accessToken);
     }
 
     @PutMapping

--- a/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/controller/MemberController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/members")
+@RequestMapping("/auths")
 @Slf4j
 
 public class MemberController {

--- a/src/main/java/com/justdo/plug/member/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/repository/MemberRepository.java
@@ -2,11 +2,16 @@ package com.justdo.plug.member.domain.member.repository;
 
 
 import com.justdo.plug.member.domain.member.Member;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {
     Optional<Member> findByProviderId(Long kakaoId);
     boolean existsByProviderId(Long kakaoId);
+
+    @Query("SELECT m FROM Member m WHERE m.id IN :memberIdList")
+    List<Member> findAllMemberIdList(List<Long> memberIdList);
 }

--- a/src/main/java/com/justdo/plug/member/domain/member/service/MemberService.java
+++ b/src/main/java/com/justdo/plug/member/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.justdo.plug.member.global.jwt.JwtTokenProvider;
 import com.justdo.plug.member.global.response.code.status.ErrorStatus;
 import com.justdo.plug.member.global.utils.redis.RedisUtils;
 import io.lettuce.core.RedisConnectionException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
@@ -119,4 +120,10 @@ public class MemberService {
         return userId;
     }
 
+    public List<String> getMemberNicknames(List<Long> memberIdList) {
+
+        return memberRepository.findAllMemberIdList(memberIdList).stream()
+            .map(Member::getNickname)
+            .toList();
+    }
 }

--- a/src/main/java/com/justdo/plug/member/global/config/SwaggerConfig.java
+++ b/src/main/java/com/justdo/plug/member/global/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.justdo.plug.member.global.config;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+
+        String jwtSchemeName = "JWT TOKEN";
+
+        // API 요청 헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        //SecuritySchemes 등록
+        Components components = new Components()
+            .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                .name(jwtSchemeName)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT"));
+
+        return new OpenAPI()
+            .addServersItem(new Server().url("/"))
+            .info(apiInfo())
+            .addSecurityItem(securityRequirement)
+            .components(components);
+    }
+
+    private Info apiInfo() {
+        return new Info()
+            .title("Glue Auth-Service Springdoc 테스트")
+            .description("Springdoc을 사용한 Glue Auth-Service UI 테스트")
+            .version("1.0.0");
+    }
+}


### PR DESCRIPTION
## 📌 요약

- 구독 페이지에서 사용자 닉네임이 필요하여 memberId 목록을 전달하여, 닉네임 반환하는 API 구현

## 📝 상세 내용

-

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
