### PR TITLE
GLUE-100 Feat: 이전 버전 카카오 로그인 api 복구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	// swagger
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.2.0'
+
+	// webclient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 

--- a/src/main/java/com/justdo/plug/auth/domain/member/controller/AuthController.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.justdo.plug.auth.domain.member.controller;
 import com.justdo.plug.auth.domain.member.dto.request.MemberInfoRequest;
 import com.justdo.plug.auth.domain.member.dto.response.MemberInfoResponse;
 import com.justdo.plug.auth.domain.member.service.MemberService;
+import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.JwtTokenResponse;
 import com.justdo.plug.auth.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,6 +23,12 @@ import java.util.List;
 public class AuthController {
 
     private final MemberService memberService;
+
+    @GetMapping("/login")
+    @Operation(summary = "카카오 로그인", description = "전달받은 인가코드를 통해 카카오 로그인을 수행한다.")
+    public ApiResponse<JwtTokenResponse> kakaoLogin(@RequestParam String code) {
+        return ApiResponse.onSuccess(memberService.processKakaoLogin(code));
+    }
 
     @GetMapping
     @Operation(summary = "로그인 한 유저 정보 조회", description = "현재 로그인한 유저의 정보를 조회한다.")

--- a/src/main/java/com/justdo/plug/auth/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/JwtTokenProvider.java
@@ -29,8 +29,8 @@ public class JwtTokenProvider {
 
     private final RedisUtils redisUtils;
 
-    public static final long ACCESS_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000; // 15분
-    public static final long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000; // 7일
+    public static final long ACCESS_TOKEN_EXPIRATION_TIME = 365L * 24 * 60 * 60 * 1000; // 1년
+    public static final long REFRESH_TOKEN_EXPIRATION_TIME = 365L * 24 * 60 * 60 * 1000; // 1년
 
     private SecretKey getSecretKey() {
         String keyBase64Encoded = Base64.getEncoder().encodeToString(secretKey.getBytes());

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/KakaoTokenJsonData.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/KakaoTokenJsonData.java
@@ -1,0 +1,49 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion;
+
+import com.justdo.plug.auth.global.exception.ApiException;
+import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response.KakaoTokenResponse;
+import com.justdo.plug.auth.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoTokenJsonData {
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${kakao.token_uri}")
+    private String tokenUri;
+
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+
+    @Value("${kakao.grant_type}")
+    private String grantType;
+
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    public KakaoTokenResponse getToken(String code) {
+        String uri = tokenUri + "?grant_type=" + grantType + "&client_id="
+                + clientId + "&redirect_uri=" + redirectUri + "&code=" + code;
+
+        log.info("uri = {}", uri);
+
+        Flux<KakaoTokenResponse> response = webClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToFlux(KakaoTokenResponse.class);
+
+        return response.onErrorMap(WebClientResponseException.class,
+                e -> new ApiException(ErrorStatus._KAKAO_TOKEN_ERROR)).blockFirst();
+    }
+
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/KakaoUserInfoJsonData.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/KakaoUserInfoJsonData.java
@@ -1,0 +1,33 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion;
+
+import com.justdo.plug.auth.global.exception.ApiException;
+import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response.KakaoUserInfoResponse;
+import com.justdo.plug.auth.global.response.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Flux;
+
+@RequiredArgsConstructor
+@Component
+public class KakaoUserInfoJsonData {
+    private final WebClient webClient = WebClient.create();
+
+    @Value("${kakao.user_info_uri}")
+    private String userInfoUri;
+
+    public KakaoUserInfoResponse getUserInfo(String token) {
+
+        Flux<KakaoUserInfoResponse> response = webClient.get()
+                .uri(userInfoUri)
+                .header("Authorization", "Bearer " + token)
+                .retrieve()
+                .bodyToFlux(KakaoUserInfoResponse.class);
+
+        return response.onErrorMap(WebClientResponseException.class, ex  -> {
+                    return new ApiException(ErrorStatus._KAKAO_USER_INFO_ERROR);})
+                .blockFirst();
+    }
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/JwtTokenResponse.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/JwtTokenResponse.java
@@ -1,0 +1,24 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class JwtTokenResponse {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public JwtTokenResponse(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static JwtTokenResponse createJwtTokenResponse(String accessToken, String refreshToken) {
+        return JwtTokenResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/KakaoAccount.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/KakaoAccount.java
@@ -1,0 +1,15 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoAccount {
+    private boolean profile_nickname_needs_agreement;
+    private boolean profile_image_needs_agreement;
+    private KakaoProfile profile;
+    private boolean has_email;
+    private boolean email_needs_agreement;
+    private boolean is_email_valid;
+    private boolean is_email_verified;
+    private String email;
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/KakaoProfile.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/KakaoProfile.java
@@ -1,0 +1,12 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoProfile {
+    private String nickname;
+    private String thumbnail_image_url;
+    private String profile_image_url;
+    private boolean is_default_image;
+    private boolean is_default_nickname;
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/KakaoProperties.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/KakaoProperties.java
@@ -1,0 +1,10 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoProperties {
+    private String nickname;
+    private String profile_image;
+    private String thumbnail_image;
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,13 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoTokenResponse {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private Integer expires_in;
+    private String scope;
+    private Integer refresh_token_expires_in;
+}

--- a/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/com/justdo/plug/auth/global/jwt/kakao/preVersion/dto/response/KakaoUserInfoResponse.java
@@ -1,0 +1,13 @@
+package com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response;
+
+
+import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.KakaoAccount;
+import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.KakaoProperties;
+import lombok.Getter;
+@Getter
+public class KakaoUserInfoResponse {
+    private Long id;
+    private String connectedAt;
+    private KakaoProperties properties;
+    private KakaoAccount kakao_account;
+}


### PR DESCRIPTION
## 📌 요약

- 쿠버네티스 배포 시 oauth2 client 이용한 로그인 기능에 이슈가 생겨 프론트로부터 인가코드를 받아 로그인을 진행하는 이전 버전 api를 복구했습니다.

## 📝 상세 내용

<img width="1025" alt="image" src="https://github.com/DoTheZ-Team/auth-service/assets/113875098/bb552f89-7b27-4285-917c-13729037a855">


- 요약과 동일

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #