### PR TITLE
GLUE-56 Fix : login api post 요청으로 변경, 토큰 재발급과 로그아웃 api 반환 wrapper 설정

### DIFF
--- a/src/main/java/com/justdo/plug/auth/domain/member/controller/AuthController.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/controller/AuthController.java
@@ -24,14 +24,14 @@ public class AuthController {
 
     private final MemberService memberService;
 
-    @GetMapping("/login")
+    @PostMapping("/login")
     @Operation(summary = "카카오 로그인", description = "전달받은 인가코드를 통해 카카오 로그인을 수행한다.")
     public ApiResponse<JwtTokenResponse> kakaoLogin(@RequestParam String code) {
         return ApiResponse.onSuccess(memberService.processKakaoLogin(code));
     }
 
     @GetMapping
-    @Operation(summary = "로그인 한 유저 정보 조회", description = "현재 로그인한 유저의 정보를 조회한다.")
+    @Operation(summary = "로그인 한 유저 정보 조회", description = "Open feign 요청입니다. / 현재 로그인한 유저의 정보를 조회한다.")
     public MemberInfoResponse getMyInfo(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
         return memberService.getMemberInfo(accessToken);
@@ -54,21 +54,24 @@ public class AuthController {
 
     @PostMapping("/logout")
     @Operation(summary = "로그인 한 유저 로그아웃", description = "현재 로그인한 유저의 로그아웃을 수행한다.")
-    public void logout(HttpServletRequest request) {
+    public ApiResponse<Object> logout(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
         memberService.logout(accessToken);
+
+        return ApiResponse.onSuccess(null);
     }
 
 
     @PostMapping("/reissue")
     @Operation(summary = "로그인 한 유저 access 토큰 재발급", description = "현재 로그인한 유저의 access 토큰을 재발급한다.")
-    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<Object> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
         String accessToken = request.getHeader("Authorization");
         String refreshToken = request.getHeader("Authorization-refresh");
 
         String newAccessToken = memberService.reissueAccessToken(accessToken, refreshToken);
 
         response.setHeader("Authorization", newAccessToken);
+        return ApiResponse.onSuccess(null);
     }
 
     @PostMapping("/blogs")

--- a/src/main/java/com/justdo/plug/auth/domain/member/service/MemberService.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/service/MemberService.java
@@ -15,11 +15,12 @@ import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response.KakaoTokenR
 import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response.KakaoUserInfoResponse;
 import com.justdo.plug.auth.global.response.code.status.ErrorStatus;
 import com.justdo.plug.auth.global.utils.redis.RedisUtils;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -111,7 +112,7 @@ public class MemberService {
         jwtTokenProvider.validateRefreshToken(refreshToken);
         Long userId = jwtTokenProvider.extractUserIdFromToken(accessToken);
 
-        jwtTokenProvider.validateStoredRefreshToken(userId.toString(), refreshToken);
+//        jwtTokenProvider.validateStoredRefreshToken(userId.toString(), refreshToken);
 
         return jwtTokenProvider.generateAccessToken(userId);
     }


### PR DESCRIPTION
## 📌 요약

- login api post 요청으로 변경, 토큰 재발급과 로그아웃 api 반환 wrapper 설정

## 📝 상세 내용

- redis 토큰 저장 부분 일단 제외하였습니다.

## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #