### PR TITLE
Glue 375 Fix: 카카오 리다이렉트 수정 및 불필요한 코드 제거

### DIFF
--- a/.github/workflows/auth-server.yaml
+++ b/.github/workflows/auth-server.yaml
@@ -3,8 +3,6 @@ name: Glue Auth Server CI/CD
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read
@@ -78,6 +76,6 @@ jobs:
           git config --global user.email "${{ secrets.EMAIL }}"
           git config --global user.name "${{ secrets.USERNAME }}"
           git add .
-          git commit -m "[skip ci] Update deployment-server.yaml"
+          git commit -m "[skip ci] Update auth-deployment.yaml"
           git remote set-url origin https://${{ secrets.GIT_TOKEN }}@github.com/${{ secrets.GIT_PROJECT }}/glue-msa-config
           git push --set-upstream origin main

--- a/src/main/java/com/justdo/plug/auth/domain/member/Member.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseTimeEntity {
 
 
     @Builder
-    public Member(Long providerId, String provider, String email, String profileUrl,
+    public Member(Long providerId, String provider, String email,
             String nickname) {
         this.providerId = providerId;
         this.provider = provider;

--- a/src/main/java/com/justdo/plug/auth/domain/member/dto/MemberInfoRequest.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/dto/MemberInfoRequest.java
@@ -16,7 +16,7 @@ public class MemberInfoRequest {
     private String nickname;
 
     @Builder
-    public MemberInfoRequest(String email, String nickname, String profileUrl) {
+    public MemberInfoRequest(String email, String nickname) {
         this.email = email;
         this.nickname = nickname;
     }

--- a/src/main/java/com/justdo/plug/auth/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/dto/MemberInfoResponse.java
@@ -13,6 +13,7 @@ public class MemberInfoResponse {
 
     @Schema(description = "유저 이메일", example = "ht0729@gachon.ac.kr")
     private String email;
+
     @Schema(description = "유저 닉네임", example = "정성실")
     private String nickname;
 

--- a/src/main/java/com/justdo/plug/auth/domain/member/service/MemberService.java
+++ b/src/main/java/com/justdo/plug/auth/domain/member/service/MemberService.java
@@ -14,12 +14,11 @@ import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.KakaoProfile;
 import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response.KakaoTokenResponse;
 import com.justdo.plug.auth.global.jwt.kakao.preVersion.dto.response.KakaoUserInfoResponse;
 import com.justdo.plug.auth.global.response.code.status.ErrorStatus;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +33,7 @@ public class MemberService {
     // 카카오 로그인 처리
     @Transactional
     public JwtTokenResponse processKakaoLogin(String code) {
+
         KakaoTokenResponse tokenResponse = kakaoTokenJsonData.getToken(code);
         KakaoUserInfoResponse userInfo = kakaoUserInfoJsonData.getUserInfo(
                 tokenResponse.getAccess_token());
@@ -58,24 +58,24 @@ public class MemberService {
     }
 
     private Member createNewMember(KakaoUserInfoResponse userInfo) {
+
         KakaoAccount kakaoAccount = userInfo.getKakao_account();
         KakaoProfile kakaoProfile = kakaoAccount.getProfile();
+
         return Member.builder()
                 .providerId(userInfo.getId())
                 .provider("kakao")
                 .email(kakaoAccount.getEmail())
                 .nickname(kakaoProfile.getNickname())
-                .profileUrl(kakaoProfile.getProfile_image_url())
                 .build();
     }
 
 
     // 멤버 정보 조회
     public MemberInfoResponse getMemberInfo(String accessToken) {
+
         jwtTokenProvider.checkToken(accessToken);
-
         Long memberId = jwtTokenProvider.extractUserIdFromToken(accessToken);
-
         Member foundmMember = findMember(memberId);
 
         return MemberInfoResponse.toMemberInfoResponse(foundmMember);
@@ -85,12 +85,10 @@ public class MemberService {
     @Transactional
     public MemberInfoResponse updateMemberInfo(String accessToken,
             MemberInfoRequest memberInfoRequest) {
+
         jwtTokenProvider.checkToken(accessToken);
-
         Long memberId = jwtTokenProvider.extractUserIdFromToken(accessToken);
-
         Member foundMember = findMember(memberId);
-
         foundMember.updateMember(memberInfoRequest);
 
         return MemberInfoResponse.toMemberInfoResponse(foundMember);


### PR DESCRIPTION
## 📌 요약

- Kakao login 리다이렉트 주소 변경하면서, 사용하지 않는 profileUrl 코드를 제거하였습니다.

## 📝 상세 내용

<img width="960" alt="image" src="https://github.com/DoTheZ-Team/auth-service/assets/103489352/2d24b309-2f26-4ee4-b439-ce87b6314aa8">

<img width="963" alt="image" src="https://github.com/DoTheZ-Team/auth-service/assets/103489352/1a309e03-5115-4768-aecd-49880f89b63e">


## 🗣️ 질문 및 이외 사항

-

## ☑️ 이슈 번호

- close #
